### PR TITLE
Fix DSE 6.7 EOSL info

### DIFF
--- a/DSE_6.7_Release_Notes.md
+++ b/DSE_6.7_Release_Notes.md
@@ -1,7 +1,7 @@
 # Release notes for DataStax Enterprise 6.7
 DSE 6.7.x is compatible with Apache Cassandra&trade; 3.11 and adds additional production-certified changes, if any. Components that are indicated with an asterisk (&ast;) (if any) are known to be updated since the prior patch version.
 
-**NOTE**: DSE `6.7.x` line has [EOL date of November 30, 2022](https://www.datastax.com/legal/supported-software).  Please consider upgrading to [DSE 6.8](./DSE_6.8_Release_Notes.md) for our latest features and patches.
+**NOTE**: DSE `6.7.x` line has [EOSL date of November 30, 2022](https://www.datastax.com/legal/supported-software).  Please consider upgrading to [DSE 6.8](./DSE_6.8_Release_Notes.md) for our latest features and patches.
 
 # DataStax Enterprise 6.7.16
 17 February 2022


### PR DESCRIPTION
Fixes note stating DSE 6.7 EOSL (and not EOL) on Nov 30th, 2022.