### PR TITLE
DSP-23094 Automatically creates a product version tag when merging PR with new release changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+----
+## Release Notes Automation
+If you name your pull-request as "Product x.y.z Release ...", after merging the
+PR, a GitHub Action will automatically create a product version tag "product-x.y.z".
+
+Supported product names are:
+ * DSE
+ * OpsCenter
+ * Studio
+ * Luna Streaming
+
+Version supports 3 sets or 4 sets of digits.

--- a/.github/workflows/release-auto-tag.yaml
+++ b/.github/workflows/release-auto-tag.yaml
@@ -1,0 +1,42 @@
+name: Release Notes Automation - product version auto tag creation
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches: ['master']
+
+jobs:
+  release_notes_auto_tag_creator:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Create product release tag
+        # https://github.com/marketplace/actions/github-script
+        uses: actions/github-script@v6
+        with:
+          script: |
+            /**
+             * Automatically create tags when Release Notes PRs are merged
+             */
+
+            const pr_title = "${{ github.event.pull_request.title }}";
+            const match = pr_title.match(/^(DSE|OpsCenter|Studio|Luna Streaming)[ ]+(\d+\.\d+\.\d+(\.\d+)?)[ ]+release/i);
+            if (!match) {
+              core.warning("Auto tagging skipped as PR title doesn't match release notes regex.")
+              return
+            }
+
+            const product = match[1];
+            const version = match[2];
+
+            const product_version_tag = product.replace(' ', '').toLowerCase() + `-${version}`; 
+
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${product_version_tag}`,
+              sha: context.sha,
+            });
+
+            core.notice(`Tag "${product_version_tag}" created successfully.`);


### PR DESCRIPTION
See commits for more info.
Tested using https://github.com/riptano/test-shared-github-actions
 * Success: [run #4089162502](https://github.com/riptano/test-shared-github-actions/actions/runs/4089162502) GitHub action succeeded creating tag
 * Ignore: [run #4089048348](https://github.com/riptano/test-shared-github-actions/actions/runs/4089048348) GitHub Action skipped because title didn't match expected pattern
 * Failure: [run #4089174098](https://github.com/riptano/test-shared-github-actions/actions/runs/4089174098) GitHub Action failed because tag already existed