### PR TITLE
DSE 6.8.36 release notes

### DIFF
--- a/3rd-party-software/DSE_6.8.36_3rd_party_software.md
+++ b/3rd-party-software/DSE_6.8.36_3rd_party_software.md
@@ -1,0 +1,488 @@
+# DataStax Enterprise 6.8.36 third-party software
+
+| Component  |  Versions  | Licenses (*) |
+|:-----------|:----------:|:-------------|
+| agrona | 0.9.26 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Airline - IO Library | 2.2.0, 2.7.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Airline - Library | 2.2.0, 2.7.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Alfredo | 0.1.7.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Amazon Ion Java | 1.0.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| An open source Java toolkit for Amazon S3 | 0.9.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ANTLR 3 Tool | 3.5.2 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| Antlr 3.4 Runtime | 3.5.2 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| ANTLR 4 Runtime | 4.7.1, 4.7.2 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| AntLR Parser Generator | 2.7.7 | [ANTLR-PD](https://spdx.org/licenses/ANTLR-PD.html) |
+| ANTLR ST4 4.0.4 | 4.0.8 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| AOP alliance | 1.0 | Public-Domain |
+| Apache Ant + ANTLR | 1.10.9 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Ant + JUnit | 1.10.9 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Ant Core | 1.10.9 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Ant Launcher | 1.10.9 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Avro | 1.7.7 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Avro IPC | 1.7.7 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Commons BeanUtils | 1.9.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Commons CLI | 1.3.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Commons Codec | 1.15 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Commons Collections | 4.1, 4.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Commons Compress | 1.21 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Commons Configuration | 1.10 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Commons IO | 2.5 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Commons Lang | 3.5 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Commons Text | 1.10.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory API ASN.1 API | 1.0.0, 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory API ASN.1 BER | 1.0.0, 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Client API | 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Codec Core | 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Codec Standalone | 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Extras ACI | 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Extras Codec | 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Extras Codec API | 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Extras Stored Procedures | 1.0.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Extras Trigger | 1.0.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Extras Util | 1.0.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API I18n | 1.0.0, 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Model | 1.0.0, 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Network MINA | 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Schema Data | 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Directory LDAP API Utilities | 1.0.0, 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Groovy | 2.5.14 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache HTTP transport v2 for the Google HTTP Client Library for Java. | 1.42.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache HttpClient | 4.5.13, 4.5.14 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Log4j API | 2.17.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Log4j Core | 2.17.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache MINA Core | 2.0.21 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache ServiceMix :: Bundles :: ANTRL | 2.7.7_5 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Thrift | 0.9.3, 0.9.3-1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Tika core | 1.25 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache TinkerPop :: Gremlin Core | 3.2.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache TinkerPop :: Gremlin Shaded | 3.2.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apache Velocity - Engine | 2.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS AdministrativePoint Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Authentication Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Authorization Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS ChangeLog Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Collective Attribute Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Core | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Core Annotations | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Core API | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Core AVL | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Core Constants | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Core Integration | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Core JNDI | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Core Shared | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS DirectoryService-WebApp bridge | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Event Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Exception Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Generalized (X) DBM Partition | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS I18n | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Interceptor to increment numeric attributes | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Interceptors for Kerberos | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS JDBM Original Implementation | 2.0.0-M3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS JDBM Partition | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Jetty HTTP Server Integration | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Journal Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS LDIF Partition | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Mavibot Partition | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS MVCC BTree implementation | 1.0.0-M8 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Normalization Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Operational Attribute Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Password Hashing Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Protocol Dhcp | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Protocol Dns | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Protocol Kerberos | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Protocol Kerberos Codec | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Protocol Ldap | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Protocol Ntp | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Protocol Shared | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Referral Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Schema Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Apacheds Server Annotations | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Server Config | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Service Builder | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Subtree Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Test Framework | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ApacheDS Triggers Interceptor | 2.0.0-M24 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| API Common | 2.2.1 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| ASM Analysis | 6.2.1, 7.0 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| ASM based accessors helper used by json-smart | 2.4.8 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ASM Commons | 6.2.1, 7.0 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| ASM Core | 6.2.1, 7.0, 9.1 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| ASM Tree | 6.2.1, 7.0 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| AssertJ fluent assertions | 3.14.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| asyncutil | 0.1.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Auto Common Libraries | 1.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| AutoFactory | 1.0.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| AutoService | 1.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| AutoValue | 1.5 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| AutoValue Annotations | 1.9 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Awaitility | 3.1.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| AWS Java SDK for Amazon S3 | 1.11.892 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| AWS Java SDK for AWS KMS | 1.11.892 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| AWS Java SDK for AWS STS | 1.11.892 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| AWS SDK for Java - BOM | 1.11.892 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| AWS SDK for Java - Core | 1.11.892 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| base64 | 2.3.8 | Public-Domain |
+| Bean Validation API | 1.0.0.GA, 1.1.0.Final | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Bouncy Castle ASN.1 Extension and Utility APIs | 1.70 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs | 1.70 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Bouncy Castle Provider | 1.70 | [MIT](https://spdx.org/licenses/MIT.html) |
+| btf | 1.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Builder | 2.8.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Byte Buddy (without dependencies) | 1.9.7 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Byte Buddy Java agent | 1.9.7 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Caffeine cache | 2.6.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Checker Qual | 2.5.3, 3.12.0, 3.25.0, 3.8.0 | [MIT](https://spdx.org/licenses/MIT.html) |
+| ClassGraph | 4.6.32 | [MIT](https://spdx.org/licenses/MIT.html) |
+| cli | 0.9 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Cloud Storage JSON API v1-rev20220705-2.0.0 | v1-rev20220705-2.0.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Code Generation Library | 3.1, 3.2.9 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Commons Collections | 3.2.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Commons Compiler | 3.0.0 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| Commons Lang | 2.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Commons Math | 3.2, 3.4.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Commons Pool | 1.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| compiler | 0.9.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Compiler Bridge | 1.3.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Compiler Interface | 1.3.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Concurrent-Trees | 2.4.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| config | 1.3.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| core | 1.1.1, 2.3.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Cryptsoft KMIP | 2.0.1m | Commercial license agreement with Cryptsoft |
+| Dagger | 2.26 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Dagger Compiler | 2.26 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Dagger Production Graphs | 2.26 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Dagger SPI | 2.26 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Disruptor Framework | 3.4.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| dnsjava | 2.1.8 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| durian | 3.4.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| EasyMock | 3.3.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Eclipse Compiler for Java(TM) | 3.15.1 | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html) |
+| ehcache | 2.10.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Elephant Bird Hadoop Compatibility | 4.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| error-prone annotations | 2.11.0, 2.5.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Esri Geometry API for Java | 2.2.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| fastparse | 0.4.2 | [MIT](https://spdx.org/licenses/MIT.html) |
+| fastparse-utils | 0.4.2 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Fastutil | 6.5.7 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| file-tree-views | 2.1.3 | [MIT](https://spdx.org/licenses/MIT.html) |
+| GAX (Google Api eXtensions) for Java | 0.104.2, 2.19.2 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| Generator | 2.8.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google APIs Client Library for Java | 2.0.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google App Engine extensions to the Google HTTP Client Library for Java. | 1.42.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google Auth Library for Java - Credentials | 1.11.0 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| Google Auth Library for Java - OAuth2 HTTP | 1.11.0 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| Google Cloud Core | 2.8.20 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google Cloud Core HTTP | 2.8.20 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google Cloud NIO | 0.124.16 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google Cloud Platform Supported Libraries | 26.1.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google Cloud Storage | 2.13.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google Guice - Core Library | 4.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google Guice - Extensions - AssistedInject | 4.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google Guice - Extensions - MultiBindings | 4.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google HTTP Client Library for Java | 1.42.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google Java Format | 1.5 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Google OAuth Client Library for Java | 1.34.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| GPars | 1.2.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| gremlin-scala | 3.2.2.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Gson | 2.9.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| GSON extensions to the Google HTTP Client Library for Java. | 1.42.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Guava InternalFutureFailureAccess and InternalFutures | 1.0.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Guava Testing Library | 31.1-jre | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Guava: Google Core Libraries for Java | 30.1.1-jre, 31.1-jre | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Hamcrest Core | 1.3 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| Hamcrest library | 1.3 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| hazelcast | 5.1.5 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| HdrHistogram | 2.1.10 | [CC0-1.0](https://spdx.org/licenses/CC0-1.0.html) |
+| Hibernate Validator Engine | 4.3.0.Final | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Hotspot compile command annotations | 1.2.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| HPPC Collections | 0.7.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| HttpCore | 4.4.13, 4.4.15, 4.4.16 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| IntelliJ IDEA Annotations | 13.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| IO | 1.3.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| io.grpc:grpc-context | 1.49.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| J2ObjC Annotations | 1.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson 2 extensions to the Google HTTP Client Library for Java. | 1.42.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson BOM | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson datatype: Guava | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson datatype: jdk8 | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson datatype: JSR310 | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson Integration for Metrics | 3.2.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson module: Old JAXB Annotations (javax.xml.bind) | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson-annotations | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson-core | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| jackson-coreutils | 2.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| jackson-databind | 2.13.4.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson-dataformat-CBOR | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| jackson-dataformat-msgpack | 0.8.16 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson-dataformat-XML | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson-dataformat-YAML | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson-JAXRS: base | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jackson-JAXRS: JSON | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| jackson-module-scala | 2.13.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JaCoCo :: Agent | 0.8.2 | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html) |
+| JaCoCo :: Ant | 0.8.2 | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html) |
+| JaCoCo :: Core | 0.8.2 | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html) |
+| JaCoCo :: Report | 0.8.2 | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html) |
+| Jakarta Activation API jar | 1.2.2 | EDL-1.0 |
+| Jakarta Bean Validation API | 2.0.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jakarta XML Binding API | 2.3.3 | EDL-1.0 |
+| Janino | 3.0.0 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| Jansi | 1.11 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Java Agent for Memory Measurements | 0.3.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Java Architecture for XML Binding 2.3 | 1.0.1.Final | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html) |
+| Java Concurrency Tools Core Library | 2.1.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Java Native Access | 4.5.0, 5.11.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Java Native Access Platform | 4.5.0, 5.11.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Java Servlet API | 3.1.0 | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html) |
+| Java UUID Generator | 3.1.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| java-xmlbuilder | 1.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JavaBeans Activation Framework | 1.2.1 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| JavaBeans Activation Framework (JAF) | 1.1.1 | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html) |
+| JavaMail API | 1.6.2 | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html) |
+| JavaPoet | 1.13.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Javassist | 3.22.0-GA, 3.24.0-GA | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| javatuples | 1.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Javax Annotation API | 1.3.2 | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html) |
+| Javax Transaction API | 1.3 | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html) |
+| javax.inject | 1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| javax.ws.rs-api | 2.1.1 | [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html) |
+| JAXB API bundle for GlassFish V3 | 2.3.0 | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html) |
+| jbool_expressions | 1.14 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JBoss Jakarta Annotations API | 2.0.1.Final | [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html) |
+| JBoss Jakarta Servlet | 2.0.0.Final | [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html) |
+| jboss-jakarta-jaxrs-api_spec | 2.0.1.Final | [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html) |
+| jcabi-log | 0.14 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| jcabi-manifests | 1.1 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| JCIP Annotations under Apache License | 1.0-1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JCL 1.2 implemented over SLF4J | 1.7.36 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JCommander | 1.82 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Aggregate :: All core Jetty | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: ALPN :: Client | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Asynchronous HTTP Client | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Continuation | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Deployers | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Http Utility | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: HTTP2 :: Client | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: HTTP2 :: Common | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: HTTP2 :: HPACK | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: HTTP2 :: Server | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: IO Utility | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: JASPI Security | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: JMX Management | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: JNDI Naming | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Plus | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Quick Start | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Rewrite Handler | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Runner | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Security | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Server Core | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Servlet Annotations | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Servlet Handling | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Utilities | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Utilities :: Ajax(JSON) | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Utility Servlets and Filters | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Webapp Application Support | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Websocket :: API | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Websocket :: Client | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Websocket :: Common | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Websocket :: javax.websocket :: Client Implementation | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Websocket :: javax.websocket.server :: Server Implementation | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Websocket :: Server | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: Websocket :: Servlet Interface | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty :: XML utilities | 9.4.49.v20220914 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty Orbit :: Activation | 1.1.0.v201105071233 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty Orbit :: Glassfish Mail | 1.4.1.v201005082020 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jetty Orbit :: JASPI API | 1.0.0.v201108011116 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JLine | 2.14.6 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| JMES Path Query library | 1.11.892 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Joda convert | 1.2, 1.8.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Joda-Time | 2.9.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JOpt Simple | 4.6 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Journal.IO | 1.4.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JSON (JavaScript Object Notation) | 20230227 | Public-Domain |
+| JSON Small and Fast Parser | 2.4.8 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| json-patch | 1.13 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JSON.simple | 1.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| json4s-ast | 3.5.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| json4s-core | 3.5.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| json4s-ext | 3.5.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| json4s-native | 3.5.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| json4s-scalap | 3.5.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JSR-250 Common Annotations for the JavaTM Platform | 1.0 | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html) |
+| Jsr166y | 1.7.0 | [CC0-1.0](https://spdx.org/licenses/CC0-1.0.html) |
+| JTS Core | 1.16.0 | EDL-1.0 |
+| JUL to SLF4J bridge | 1.7.36 | [MIT](https://spdx.org/licenses/MIT.html) |
+| JUnit | 4.13.2 | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html) |
+| JUnit Jupiter API | 5.4.2 | [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html) |
+| JUnit Jupiter Engine | 5.4.2 | [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html) |
+| JUnit Platform Commons | 1.4.2 | [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html) |
+| JUnit Platform Engine API | 1.4.2 | [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html) |
+| JUnit Platform Launcher | 1.4.2 | [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html) |
+| JUnit Toolbox | 2.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JUnitBenchmarks | 0.7.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JUnitParams | 1.0.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JVM Attach API | 1.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| JVM Integration for Metrics | 3.2.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Jython | 2.7.1 | [PSF-2.0](https://spdx.org/licenses/PSF-2.0.html) |
+| Kryo | 3.0.3, 4.0.2 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| kryo serializers | 0.37 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Launcher Interface | 1.0.0 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| lenses | 0.4.12 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Log4j Implemented Over SLF4J | 1.7.36 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Logback Classic Module | 1.2.11 | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html) |
+| Logback Core Module | 1.2.11 | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html) |
+| Lucene Benchmark | 6.1.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Lucene Core | 7.5.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| LZ4 and xxHash | 1.4.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| macros | 3.2.2.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Metrics Core | 3.2.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Metrics Core Library | 2.2.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Metrics Health Checks | 3.2.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Metrics Integration for Logback | 3.2.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| metrics reporter config 3.x | 3.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| metrics reporter config base | 3.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| metrics-scala | 3.5.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| MicroProfile Config API | 2.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Microsoft Azure client library for Blob Storage | 12.16.1 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Microsoft Azure client library for Identity | 1.5.1 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Microsoft Azure common module for Storage | 12.15.2 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Microsoft Azure internal Avro module for Storage | 12.2.2 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Microsoft Azure Java Core Library | 1.28.0 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Microsoft Azure OkHttp HTTP Client Library | 1.9.0 | [MIT](https://spdx.org/licenses/MIT.html) |
+| MinLog | 1.3.0 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| Mobility-RPC | 1.2.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| mockito-core | 3.0.0 | [MIT](https://spdx.org/licenses/MIT.html) |
+| mockito-inline | 3.0.0 | [MIT](https://spdx.org/licenses/MIT.html) |
+| msal4j | 1.12.0 | [MIT](https://spdx.org/licenses/MIT.html) |
+| msal4j-persistence-extension | 1.1.0 | [MIT](https://spdx.org/licenses/MIT.html) |
+| msg-simple | 1.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| msgpack-core | 0.8.16 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Mxdump | 0.10.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| net.ltgt.gradle.incap:incap | 0.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Nimbus Content Type | 2.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Nimbus JOSE+JWT | 9.21 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Nimbus LangTag | 1.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Ning-compress-LZF | 1.0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Non-Blocking Reactive Foundation for the JVM | 3.4.17 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| OAuth 2.0 SDK with OpenID Connect extensions | 9.32 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Objenesis | 2.1, 2.5.1, 2.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| OHC core | 0.7.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| OkHttp | 4.9.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Okio | 2.8.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| OpenCensus | 0.31.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| opencsv | 2.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| org.jetbrains.kotlin:kotlin-stdlib | 1.3.50, 1.4.10 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| org.jetbrains.kotlin:kotlin-stdlib-common | 1.3.50, 1.4.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| org.jetbrains.kotlinx:kotlinx-metadata-jvm | 0.1.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| org.opentest4j:opentest4j | 1.1.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ParaNamer Core | 2.8 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| parser | 0.10.4 | [MIT](https://spdx.org/licenses/MIT.html) |
+| picocli - a mighty tiny Command Line Interface | 4.1.1, 4.3.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| proto-google-common-protos | 2.9.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| proto-google-iam-v1 | 1.6.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Protocol Buffer Java API | 3.0.0-beta-1, 3.16.3, 3.21.7 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| Protocol Buffers [Util] | 3.21.7 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| psjava | 0.1.19 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Py4J | 0.10.7 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| QDox | 1.12.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| QuickTheories | 0.26 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| RandomizedTesting Randomized Runner | 2.1.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| reactive-streams | 1.0.2, 1.0.3 | [CC0-1.0](https://spdx.org/licenses/CC0-1.0.html) |
+| ReflectASM | 1.10.1, 1.11.3 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| Reflections | 0.9.10 | [WTFPL](https://spdx.org/licenses/WTFPL.html) |
+| reload4j | 1.2.19 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| RESTEasy Jackson 2 Provider | 4.6.0.Final | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| RESTEasy JAX-RS Client | 4.6.0.Final | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| RESTEasy JAX-RS Client API | 4.6.0.Final | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| RESTEasy JAX-RS Core | 4.6.0.Final | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| RESTEasy JAX-RS Core SPI | 4.6.0.Final | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| RESTEasy Netty 4 Integration | 4.6.0.Final | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| RoaringBitmap | 0.7.45 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| rxjava | 1.3.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| RxJava | 2.2.7 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| rxjava-string | 1.1.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| rxjava2-extensions | 0.20.5 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| rxscala | 0.26.5 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Saxon-HE | 9.9.1-5 | [MPL-2.0](https://spdx.org/licenses/MPL-2.0.html) |
+| SBinary | 0.4.4 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Scala Compiler | 2.11.12, 2.12.8 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) AND [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Scala Library | 2.11.12, 2.12.8 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) AND [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| scala-async | 0.9.6 | new-BSD |
+| scala-logging | 3.5.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| scala-parser-combinators | 1.0.6, 1.1.2 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) AND [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| scala-xml | 1.0.5, 1.0.6 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| scalapb-runtime | 0.6.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| scalatest | 2.2.6 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| scopt | 3.7.0 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Serial | 2.8.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| shaded-scalajson | 1.0.0-M4 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| Shims | 0.7.45 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SIGAR | 1.6.4 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SJK CLI | 0.10.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SJK Core | 0.10.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SJK Hflame | 0.10.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SJK JFR | 0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SJK NPS | 0.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SJK Stacktrace | 0.10.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| sjson new core | 0.8.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| sjson-new-scalajson | 0.8.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SLF4J API Module | 1.7.36 | [MIT](https://spdx.org/licenses/MIT.html) |
+| SmallRye Common: Annotations | 1.5.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SmallRye Common: Classloader | 1.5.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SmallRye Common: Constraints | 1.5.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SmallRye Common: Expressions | 1.5.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SmallRye Common: Functions | 1.5.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SmallRye: Common classes | 2.0.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SmallRye: MicroProfile Config CDI Implementation | 2.0.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SmallRye: MicroProfile Config Core Implementation | 2.0.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| SnakeYAML | 1.33 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Snappy for Java | 1.1.7.2 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| snowball-stemmer | 1.3.0.581.1 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| sourcecode | 0.1.3 | [MIT](https://spdx.org/licenses/MIT.html) |
+| Spotify DNS wrapper library | 3.1.5 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| spray-json | 1.3.5 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Stax2 API | 4.2.1 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| stream-lib | 2.7.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| StreamEx | 0.6.5 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| swagger-annotations | 2.0.8 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| swagger-core | 2.0.8 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| swagger-integration | 2.0.8 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| swagger-jaxrs2 | 2.0.8 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| swagger-models | 2.0.8 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| testng | 6.13.1 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| The Multiverse Code (so API and implementation) | 0.7.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| ThreeTen backport | 1.6.2 | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) |
+| Tomcat Annotations API | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat API | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat EL API | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat Embed Core | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat Embed EL | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat Embed Jasper | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat Jasper | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat Jasper EL | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat JSP API | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat JULI | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat Servlet API | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat Utilities | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Tomcat Utilities Scan | 8.5.89 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Util Control | 1.3.0 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| Util Interface | 1.3.0 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| Util Logging | 1.3.0 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| Util Relation | 1.3.0 | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) |
+| Value | 2.8.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Value Annotations | 2.8.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| Value Processor | 2.8.3 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| WebSocket client API | 1.0 | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html) |
+| WebSocket server API | 1.0 | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html) |
+| WikiText :: Core | 1.3 | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html) |
+| WikiText :: Textile :: Core | 1.3 | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html) |
+| Woodstox | 6.4.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| zinc | 1.3.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| zinc ApiInfo | 1.3.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| zinc Classfile | 1.3.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| zinc Classpath | 1.3.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| zinc Compile Core | 1.3.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| zinc Core | 1.3.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+| zinc Persist | 1.3.0 | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) |
+
+(*) Lists licenses in use by DataStax. In cases with multiple versions of a component, and the versions have different licenses, each individual license is listed.

--- a/DSE_6.8_Release_Notes.md
+++ b/DSE_6.8_Release_Notes.md
@@ -2,6 +2,41 @@
 DSE 6.8.x is compatible with Apache Cassandra&trade; 3.11 and adds additional production-certified changes, if any.
 Components that are indicated with an asterisk (&ast;) (if any) are known to be updated since the prior patch version.
 
+# Release notes for 6.8.36
+12 June 2023
+
+## Components versions for DSE 6.8.36
+ * Apache Solr™ 6.0.1.4.2959
+ * Apache Spark™ 2.4.0.28&ast;
+ * Apache TinkerPop™ 3.4.14-20230523-37856751&ast;
+ * Apache Tomcat® 8.5.89&ast;
+ * DSE Java Driver 1.10.0-dse-20220616 (DSE *internal-only* version)
+ * Netty 4.1.86.1.dse
+ * Spark JobServer 0.8.0.54&ast;
+
+**NOTE**: above-listed DSE Java Driver is an _internal-version_ only.
+If you're developing applications, please refer to the [Java Driver documentation](https://docs.datastax.com/en/driver-matrix/doc/java-drivers.html) to choose an appropriate version.
+
+## 6.8.36 DSE Core
+* Fixed compaction to ensure tombstones are not pruned for data in SSTables that are excluded from the compaction due to limited disk space. This fixes CASSANDRA-18507. (DSP-23305)
+
+## 6.8.36 DSE Cassandra
+* Improved logging around index summary building. Introduced rounding that effectively uses the `min_index_interval` option set to a multiple of 128 in the index summary building process. (DSP-23317)
+
+## 6.8.36 DSE Search
+* Fixed the bug in the Solr UI permissions when accessing segments information. It was not working with authorization enabled by implementing a  segments view when granting the `SELECT` permission on the Solr-indexed table. (DSP-22295)
+
+## 6.8.36 DSE Node/DseTool
+* Added `--key` option to dsetool encryptconfigvalue command to allow using different key than the default one. (DSP-23326)
+
+## 6.8.36 DSE Miscellaneous
+* Fixed memory leak in the chunk cache metadata caching. (DSP-23316)
+
+## 6.8.36 DSE CVE
+* Upgraded commons-net library used in Hadoop and Tinkerpop. Removed old Hadoop `1.0.3` dependency and replaced it with version universally used in DSE (`2.7.1.x` for 5.1  and `2.10.2.x` for 6.8). (DSP-23327, [CVE-2021-37533](https://nvd.nist.gov/vuln/detail/CVE-2021-37533), [CVE-2012-4449](https://nvd.nist.gov/vuln/detail/CVE-2012-4449))
+* Upgraded Apache Tomcat to version `8.5.89`. (DSP-23329, [CVE-2023-28709](https://nvd.nist.gov/vuln/detail/CVE-2023-28709))
+
+
 # Release notes for 6.8.35
 10 May 2023
 


### PR DESCRIPTION
DSE 6.8.36 release notes and 3rd-party listing.

----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
