### PR TITLE
DSP-22612 Fixes DSE 6.8 and 5.1 for Oracle Linux support

### DIFF
--- a/DSE_5.1_Release_Notes.md
+++ b/DSE_5.1_Release_Notes.md
@@ -82,6 +82,7 @@ If you're developing applications, please refer to the [Java Driver documentatio
 
 ## 5.1.39 DSE Platform
 * Added support for Red Hat Enterprise Linux 9. (DSP-23444)
+* Added support for Oracle Linux 9. (DSP-22612)
 
 ## Components versions for DSE 5.1.39
  * Apache Solr™ 6.0.1.0.2961

--- a/DSE_6.8_Release_Notes.md
+++ b/DSE_6.8_Release_Notes.md
@@ -154,6 +154,7 @@ If you're developing applications, please refer to the [Java Driver documentatio
 
 ## 6.8.37 DSE Platform
 * Added support for Red Hat Enterprise Linux 9. (DSP-23229)
+* Added support for Oracle Linux 9. (DSP-22612)
 
 ## Components versions for DSE 6.8.37
  * Apache Solr™ 6.0.1.4.2959
@@ -315,6 +316,7 @@ If you're developing applications, please refer to the [Java Driver documentatio
 ## 6.8.33 DSE Platform
 * Added support for Rocky Linux 9. (DSP-22732)
 * Added support for Rocky Linux 8. (DSP-23170)
+* Added support for Oracle Linux 9. (DSP-22612)
 
 ## 6.8.33 DSE Miscellaneous
 * Fixed RPM package install for platforms requiring systemd services. (DSP-23146)


### PR DESCRIPTION
Fixes DSE 6.8.37 and 5.1.39 release notes to add Oracle Linux support which should have been supported since when we supported Red Hat 9.

----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
