### PR TITLE
Adds warning about storage cluster regression introduced in 6.8.33

### DIFF
--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -2,7 +2,8 @@
 
 # Release Notes for OpsCenter 6.8.33
 15 Feb 2024
-:warning: Customers using separate storage clusters are not recommended to use this release as it could break opscenterd. Please use version 6.8.32 or wait until the next release, which will be released shortly with a fix. The identified issue wouldn't impact you if there wasn't a separate storage cassandra cluster configured.
+
+:warning: Customers using a separate storage cluster for metrics are advised to not use this release as OpsCenter will fail to start. Please use version 6.8.32 or wait until the next release, which will be released shortly with a fix.
 
 ## Backup Service
 * Improved handling encryption keys in collision, keys from system tables will be ignored during restore. (OPSC-17115)

--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -2,6 +2,7 @@
 
 # Release Notes for OpsCenter 6.8.33
 15 Feb 2024
+:warning: Customers using separate storage clusters are not recommended to use this release as it could break opscenterd. Please use version 6.8.32 or wait until the next release, which will be released shortly with a fix. The identified issue wouldn't impact you if there wasn't a separate storage cassandra cluster configured.
 
 ## Backup Service
 * Improved handling encryption keys in collision, keys from system tables will be ignored during restore. (OPSC-17115)


### PR DESCRIPTION
----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
