### PR TITLE
OpsCenter 6.8.34 Release

### DIFF
--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -1,5 +1,12 @@
 # Release notes for OpsCenter
 
+# Release Notes for OpsCenter 6.8.34
+22 Feb 2024
+
+## Core
+* Fixed OpsCenter startup failure for customers using a separate storage cluster. Added {{{{alert_on_no_host_available}}}} to the {{{{[storage_cassandra]}}}} section of the cluster conf. When set to {{true}} an alert will be triggered if opscenterd is unable to make a cql connection to the storage cluster. (OPSC-17488)
+* Added {{{{heartbeat_warn_window}}}} to the {{{{[failover]}}}} section of the opscenterd conf. When set to non zero integer value (seconds), Backup OpsCenter triggers an alert if it does not receive heartbeat from Primary OpsCenter in the given window and added {{{{heartbeat_log_level}}}} to the {{{{[failover]}}}} section of the opscenterd conf. When set to one of these values in {{{info, debug, trace}}} primary and backup OpsCenter logs all the heartbeat communication activities at the set level. (OPSC-17388)
+
 # Release Notes for OpsCenter 6.8.33
 15 Feb 2024
 


### PR DESCRIPTION
----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
