### PR TITLE
Update DSP-23187 release note

### DIFF
--- a/DSE_6.8_Release_Notes.md
+++ b/DSE_6.8_Release_Notes.md
@@ -539,7 +539,7 @@ If you're developing applications, please refer to the [Java Driver documentatio
 * Fixed regression scenario where DSE was not using keys on the KMIP server that were created either by a previous DSE version or outside of DSE. Regression was introduced in DSE v6.8.22. (DSP-23182)
 
 ## 6.8.34 DSE CVE
-* Upgraded `org.json:json` to `20230227` to resolve a Denial of Service (DoS) vulnerability. In addition, upgraded `esri-geometry-api` to `2.2.4`. (DSP-23187, [CWE-400](https://nvd.nist.gov/vuln/detail/CWE-400))
+* Upgraded `org.json:json` to `20230227` to resolve a Denial of Service (DoS) vulnerability. Additionally, upgraded `esri-geometry-api` to `2.2.4`, which now follows the OGC and GeoJSON standard for polygon serialization. As a result, polygons' JSON representation is serialized with the exterior polygon in counterclockwise order and interior polygons (holes) in clockwise order. (DSP-23187, [CWE-400](https://nvd.nist.gov/vuln/detail/CWE-400))
 * Upgraded commons-fileupload to 1.5. Added a solrconfig.xml setting that limits the number of files allowed in multipart update requests. (DSP-23188, [CVE-2023-24998](https://nvd.nist.gov/vuln/detail/CVE-2023-24998))
 * Upgraded Apache Tomcat to version 8.5.87. (DSP-23205, [CVE-2023-24998](https://nvd.nist.gov/vuln/detail/CVE-2023-24998))
 


### PR DESCRIPTION
This commit amends the release note of DSP-23187 by adding the remark about the order of polygon points in the JSON representation.

----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
