### PR TITLE
Update DSE_6.8_Release_Notes.md

### DIFF
--- a/DSE_6.8_Release_Notes.md
+++ b/DSE_6.8_Release_Notes.md
@@ -30,6 +30,9 @@ If you're developing applications, please refer to the [Java Driver documentatio
 * Updated DSE Java Driver with fix for JAVA-2738. (DSP-24514)
 * Updated DSE Java Driver with fix for JAVA-3125. (DSP-24556)
 
+## 6.8.52 DSE Platform
+* Added support for Amazon Linux 2023 (DSP-23827).
+
 ## 6.8.52 DSE CVE
 * Updated the spark version to `2.4.0.31` to pull in the latest ivy library (vs 2.5.2) for a vulnerability fix. (DSP-23685, [CVE-2022-46751](https://nvd.nist.gov/vuln/detail/CVE-2022-46751))
 * Upgraded tomcat-embed-core to version `8.5.100`. (DSP-24013, [CVE-2023-46589](https://nvd.nist.gov/vuln/detail/CVE-2023-46589))


### PR DESCRIPTION
Adds information about support for Amazon Linux 2023 platform

----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
