### PR TITLE
DSP-24766-69: Update the DSE_6.9_Release_Notes.md with the minimum JDK and Python versions

### DIFF
--- a/DSE_6.9_Release_Notes.md
+++ b/DSE_6.9_Release_Notes.md
@@ -230,4 +230,4 @@ If you're developing applications, please refer to the [Java Driver documentatio
 
 ## 6.9.0 DSE Upgrade
 
-* To upgrade to DSE 6.9 from an earlier release, you need to install the Java Development Kit (JDK) version `11.0.19` or later, and Python `3.8` to `3.11`. For more information, see [Preparing to upgrade](https://docs.datastax.com/en/upgrading/datastax-enterprise/dse-68-to-69.html#preparing-to-upgrade).
+* To upgrade to DSE 6.9 from an earlier release, you need to install the Java Development Kit (JDK) version `11.0.2` or later, and Python `3.8` to `3.11`. In general, follow the guidance listed in the Release Notes and upgrade to the Java and Python versions recommended for a specific DSE 6.9 release. For more information, see [Preparing to upgrade](https://docs.datastax.com/en/upgrading/datastax-enterprise/dse-68-to-69.html#preparing-to-upgrade).

--- a/DSE_6.9_Release_Notes.md
+++ b/DSE_6.9_Release_Notes.md
@@ -230,4 +230,4 @@ If you're developing applications, please refer to the [Java Driver documentatio
 
 ## 6.9.0 DSE Upgrade
 
-* To upgrade to DSE 6.9 from an earlier release, you need to install the Java Development Kit (JDK) version `11.0.2` or later, and Python `3.8` to `3.11`. In general, follow the guidance listed in the Release Notes and upgrade to the Java and Python versions recommended for a specific DSE 6.9 release. For more information, see [Preparing to upgrade](https://docs.datastax.com/en/upgrading/datastax-enterprise/dse-68-to-69.html#preparing-to-upgrade).
+* To upgrade to DSE 6.9 from an earlier release, you need to install the Java Development Kit (JDK) version `11.0.2` or later, and Python `3.8` to `3.11`. In general, follow the guidance listed in the Release Notes and upgrade to the JDK and Python versions recommended for a specific DSE 6.9 release. For more information, see [Preparing to upgrade](https://docs.datastax.com/en/upgrading/datastax-enterprise/dse-68-to-69.html#preparing-to-upgrade).

--- a/DSE_6.9_Release_Notes.md
+++ b/DSE_6.9_Release_Notes.md
@@ -227,3 +227,7 @@ This is the first version of DSE 6.9 having Java 11 and Vector support.
 
 **NOTE**: above-listed DSE Java Driver is an _internal-version_ only.
 If you're developing applications, please refer to the [Java Driver documentation](https://docs.datastax.com/en/driver-matrix/doc/java-drivers.html) to choose an appropriate version.
+
+## 6.9.0 DSE Upgrade
+
+* To upgrade to DSE 6.9 from an earlier release, you need to install the Java Development Kit (JDK) version `11.0.19` or later, and Python `3.8` to `3.11`. For more information, see [Preparing to upgrade](https://docs.datastax.com/en/upgrading/datastax-enterprise/dse-68-to-69.html#preparing-to-upgrade).


### PR DESCRIPTION
Per the request in https://datastax.jira.com/browse/DSP-24766, this PR adds the required minimum JDK (11.0.19) and Python (3.8 - 3.11) versions required to run DSE 6.9.

----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
