### PR TITLE
Added missing release note for OPSC-17614

### DIFF
--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -24,6 +24,7 @@
 * Fixed an issue for handling special characters in dropped columns when restoring a table schema. (OPSC-17640)
 * Enabled the compression option for Azure backup destinations. (OPSC-17654)
 * Fixed an issue that prevented the backup and restore of tables using Storage-Attached Indexes (SAI) in DSE 6.9. (OPSC-17678)
+* Introduced a new agent config option `azcopy_max_files` which controls the maximum number of files that will uploaded via azcopy at once. (OPSC-17614)
 
 ## Monitoring
 * Resolved an issue that caused HTML tags to appear in the description of triggered alerts. (OPSC-17624)

--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -24,7 +24,7 @@
 * Fixed an issue for handling special characters in dropped columns when restoring a table schema. (OPSC-17640)
 * Enabled the compression option for Azure backup destinations. (OPSC-17654)
 * Fixed an issue that prevented the backup and restore of tables using Storage-Attached Indexes (SAI) in DSE 6.9. (OPSC-17678)
-* Introduced a new agent config option `azcopy_max_files` which controls the maximum number of files that will uploaded via azcopy at once. (OPSC-17614)
+* Introduced `azcopy_max_files`, an agent configuration option to control the maximum number of files that the azcopy utility uploads at the same time. (OPSC-17614)
 
 ## Monitoring
 * Resolved an issue that caused HTML tags to appear in the description of triggered alerts. (OPSC-17624)


### PR DESCRIPTION
----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
