### PR TITLE
OPSC-17698 OpsCenter 6.8.44 Release

### DIFF
--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -9,7 +9,7 @@
 
 ## Monitoring
 * Added support for alerting on the disk partitions used for the DSE `cdc_raw_directory` and agent log directory. (OPSC-17650)
-* Fixed a bug that made LDAP authentication unusable. (OPSC-17688)
+* Fixed an issue that made LDAP authentication unusable. (OPSC-17688)
 
 # Release Notes for OpsCenter 6.8.43
 31 March 2025

--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -1,5 +1,16 @@
 # Release notes for OpsCenter
 
+# Release Notes for OpsCenter 6.8.44
+25 April 2025
+
+## Core
+* Certified OpsCenter running on `Amazon Linux 2023`. (OPSC-17676)
+* Added a new configuration option `enable_curl` in `posturl.conf` to allow alerts to use the curl command (default is `False`). (OPSC-17177)
+
+
+## Monitoring
+* Introduced a new variable `agent_log_location` under the agents section in `cluster.conf`. This complements the existing `log_location` under the cassandra section. Both variables should now be specified when customizing log directories, as they determine the respective log partitions for Cassandra and the Agent components. (OPSC-17650)
+
 # Release Notes for OpsCenter 6.8.43
 31 March 2025
 

--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -5,7 +5,7 @@
 
 ## Core
 * Added support for running OpsCenter on Amazon Linux 2023. (OPSC-17676)
-* Added a new configuration option `enable_curl` in `posturl.conf` to allow alerts to use the curl command (default is `False`). (OPSC-17177)
+* Added a new configuration option, `enable_curl`, in the `posturl.conf` file. This option enables alerts to use the `curl` command. The default setting is `False`, which disables this option. To enable this option, set `enable_curl` to `True`. (OPSC-17177)
 
 ## Monitoring
 * Added support for alerting on the disk partitions used for the DSE `cdc_raw_directory` and agent log directory. (OPSC-17650)

--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -4,7 +4,7 @@
 25 April 2025
 
 ## Core
-* Certified OpsCenter running on `Amazon Linux 2023`. (OPSC-17676)
+* Added support for running OpsCenter on Amazon Linux 2023. (OPSC-17676)
 * Added a new configuration option `enable_curl` in `posturl.conf` to allow alerts to use the curl command (default is `False`). (OPSC-17177)
 
 ## Monitoring

--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -7,9 +7,9 @@
 * Certified OpsCenter running on `Amazon Linux 2023`. (OPSC-17676)
 * Added a new configuration option `enable_curl` in `posturl.conf` to allow alerts to use the curl command (default is `False`). (OPSC-17177)
 
-
 ## Monitoring
-* Introduced a new variable `agent_log_location` under the agents section in `cluster.conf`. This complements the existing `log_location` under the cassandra section. Both variables should now be specified when customizing log directories, as they determine the respective log partitions for Cassandra and the Agent components. (OPSC-17650)
+* Added support for alerting on the disk partitions used for the DSE `cdc_raw_directory` and agent log directory. (OPSC-17650)
+* Fixed a bug that made LDAP authentication unusable. (OPSC-17688)
 
 # Release Notes for OpsCenter 6.8.43
 31 March 2025

--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -8,7 +8,7 @@
 * Added a new configuration option, `enable_curl`, in the `posturl.conf` file. This option enables alerts to use the `curl` command. The default setting is `False`, which disables this option. To enable this option, set `enable_curl` to `True`. (OPSC-17177)
 
 ## Monitoring
-* Added support for alerting on the disk partitions used for the DSE `cdc_raw_directory` and agent log directory. (OPSC-17650)
+* Added cassandra log, agent log, and the cdc_raw as options to alerts by partition function. (OPSC-17650)
 * Fixed an issue that made LDAP authentication unusable. (OPSC-17688)
 
 # Release Notes for OpsCenter 6.8.43


### PR DESCRIPTION
----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
