### PR TITLE
Update DSE 6.8/6.9 release notes to include fixed CVEs

### DIFF
--- a/DSE_6.8_Release_Notes.md
+++ b/DSE_6.8_Release_Notes.md
@@ -28,6 +28,8 @@ If you're developing applications, please refer to the [Java Driver documentatio
 * Fixed a timeout issue for SAI and range queries. This fix prevents draining nodes from replying to echo messages and stops these nodes from executing faulty requests. (DSP-24792)
 * Fixed an issue where incremental repairs failed during compaction. (DSP-24922)
 
+## 6.8.60 DSE CVE
+* Upgraded Netty to version `4.1.127.1.dse`, which is based on version `4.1.127.Final`. (DSP-24941, DSP-24942, [CVE-2505-55163](https://nvd.nist.gov/vuln/detail/CVE-2505-55163), [CVE-2025-58506](https://nvd.nist.gov/vuln/detail/CVE-2025-58056))
 
 # Release notes for 6.8.59
 26 June 2025

--- a/DSE_6.9_Release_Notes.md
+++ b/DSE_6.9_Release_Notes.md
@@ -24,6 +24,10 @@ If you're developing applications, please refer to the [Java Driver documentatio
 ## 6.9.14 DSE Cassandra
 * Fixed an issue where SSTables with implicitly frozen UDTs, including those with dropped columns, became unreadable during upgrades. (DSP-24600)
 
+## 6.9.14 DSE CVE
+* Upgraded Netty to version `4.1.127.1.dse`, which is based on version `4.1.127.Final`. (DSP-24941, DSP-24942, [CVE-2505-55163](https://nvd.nist.gov/vuln/detail/CVE-2505-55163), [CVE-2025-58506](https://nvd.nist.gov/vuln/detail/CVE-2025-58056))
+* Upgraded Management API component to pick up version 3.18.0 of Apache commons-lang2. (DSP-24941, [CVE-2025-48924](https://nvd.nist.gov/vuln/detail/CVE-2025-48924))
+
 # Release notes for 6.9.13
 11 August 2025
 


### PR DESCRIPTION
This isn't meant to create new tags, just update the release notes for DSE 6.8.60 and 6.9.14 to include the missing CVE information

----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
