### PR TITLE
Add CODEOWNERS with list of approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+##############################################################
+#
+# List of approvers for IBM DataStax Product's release notes
+#
+##############################################################
+
+# DataStax Enterprise
+DSE_*.md @annieden @brian-r-fisher
+3rd-party-software/DSE_*.md @annieden @brian-r-fisher
+
+# DataStax OpsCenter
+OpsCenter_*.md @annieden @brian-r-fisher


### PR DESCRIPTION
Ensure DSE + OpsCenter Release Notes are only merged after Docs team approval.
----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
