### PR TITLE
OPSC-17970 Add missing netty upgrade release note

### DIFF
--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -24,6 +24,7 @@ Significant QA process improvements are in process to avoid similar future issue
 ## Security
 * Upgraded `dojo`, `dijit`, `dojox`, and `dojo-util` to version 1.17.3, addressing CVE-2021-23450 (CWE-1321: Improperly Controlled Modification of Object Prototype Attributes Prototype Pollution). (OPSC-17877)
 * Updated `jackson` to version 2.21.4 to address CVE-2026-54512. (OPSC-17976)
+* Upgraded `netty` from version 4.1.133 to 4.1.135 addressing CVE-2026-44249 (OPSC-17970)
 
 # Release Notes for OpsCenter 6.8.51
 28 May 2026

--- a/OpsCenter_6.8_Release_Notes.md
+++ b/OpsCenter_6.8_Release_Notes.md
@@ -24,7 +24,7 @@ Significant QA process improvements are in process to avoid similar future issue
 ## Security
 * Upgraded `dojo`, `dijit`, `dojox`, and `dojo-util` to version 1.17.3, addressing CVE-2021-23450 (CWE-1321: Improperly Controlled Modification of Object Prototype Attributes Prototype Pollution). (OPSC-17877)
 * Updated `jackson` to version 2.21.4 to address CVE-2026-54512. (OPSC-17976)
-* Upgraded `netty` from version 4.1.133 to 4.1.135 addressing CVE-2026-44249 (OPSC-17970)
+* Upgraded `netty` from version 4.1.133 to 4.1.135 addressing CVE-2026-44249 (OPSC-17970).
 
 # Release Notes for OpsCenter 6.8.51
 28 May 2026


### PR DESCRIPTION
OPSC-17970 was missing the doc impact field so it didn't get picked up by the release notes generator. This adds the missing release note.

The opscenter release notes generator has been updated to list all tickets in the release without release notes to make this kind of thing easier to prevent in the future.

----
## Release Notes Automation
If you name your pull-request as "Product x.y.z Release ...", after merging the
PR, a GitHub Action will automatically create a product version tag "product-x.y.z".

Supported product names are:
 * DSE
 * OpsCenter
 * Studio
 * Luna Streaming

Version supports 3 sets or 4 sets of digits.
